### PR TITLE
Refactor log parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>sauce-ondemand</artifactId>
-    <version>1.151-SNAPSHOT</version>
+    <version>1.151</version>
     <packaging>hpi</packaging>
     <name>Jenkins Sauce OnDemand plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Sauce+OnDemand+Plugin</url>
@@ -26,7 +26,7 @@
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/sauce-ondemand-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/sauce-ondemand-plugin.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>sauce-ondemand-1.151</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <plugins.junit.version>1.9</plugins.junit.version>
         <plugins.workflow.version>1.15</plugins.workflow.version>
         <ci-sauce.version>1.113</ci-sauce.version>
-        <sauce.rest.version>1.0.32</sauce.rest.version>
+        <sauce.rest.version>1.0.33</sauce.rest.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>sauce-ondemand</artifactId>
-    <version>1.151</version>
+    <version>1.152-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Sauce OnDemand plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Sauce+OnDemand+Plugin</url>
@@ -26,7 +26,7 @@
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/sauce-ondemand-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/sauce-ondemand-plugin.git</developerConnection>
-        <tag>sauce-ondemand-1.151</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -1,6 +1,7 @@
 package hudson.plugins.sauce_ondemand;
 
 import com.saucelabs.ci.Browser;
+import hudson.maven.MavenBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildableItemWithBuildWrappers;
@@ -12,6 +13,7 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.Nonnull;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
@@ -210,9 +212,13 @@ public final class SauceEnvironmentUtil {
      * @param build the Jenkins build
      * @return String representing the Jenkins build
      */
+    @Nonnull
     public static String getBuildName(AbstractBuild<?, ?> build) {
         if (build == null) {
             return "";
+        }
+        while (build instanceof MavenBuild && ((MavenBuild) build).getParentBuild() != null) {
+            build = ((MavenBuild) build).getParentBuild();
         }
 
         String displayName = build.getFullDisplayName();

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -1,6 +1,5 @@
 package hudson.plugins.sauce_ondemand;
 
-import com.google.common.collect.Lists;
 import com.saucelabs.ci.JobInformation;
 import com.saucelabs.saucerest.SauceREST;
 import hudson.model.AbstractBuild;
@@ -15,11 +14,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,7 +43,7 @@ public class SauceOnDemandBuildAction extends AbstractAction {
     public static final Pattern SESSION_ID_PATTERN = Pattern.compile("SauceOnDemandSessionID=([0-9a-fA-F]+)(?:.job-name=(.*))?");
 
     private AbstractBuild<?, ?> build;
-    private transient List<JobInformation> jobInformation;
+    private List<JobInformation> jobInformation;
     @Deprecated
     private String accessKey;
     @Deprecated
@@ -103,7 +98,7 @@ public class SauceOnDemandBuildAction extends AbstractAction {
 
         String buildNumber = SauceOnDemandBuildWrapper.sanitiseBuildNumber(SauceEnvironmentUtil.getBuildName(build));
         logger.fine("Performing Sauce REST retrieve results for " + buildNumber);
-        String jsonResponse = sauceREST.getBuildFullJobs(buildNumber);
+        String jsonResponse = sauceREST.getBuildFullJobs(buildNumber, 5000);
         JSONObject job = new JSONObject(jsonResponse);
         JSONArray jobResults = job.getJSONArray("jobs");
         if (jobResults == null) {
@@ -111,7 +106,7 @@ public class SauceOnDemandBuildAction extends AbstractAction {
 
         } else {
             //the list of results retrieved from the Sauce REST API is last-first, so reverse the list
-            for (int i = jobResults.length(); i > 0; i--) {
+            for (int i = jobResults.length() - 1; i > 0; i--) {
                 //check custom data to find job that was for build
                 JSONObject jobData = jobResults.getJSONObject(i);
                 String jobId = jobData.getString("id");

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -1,10 +1,10 @@
 package hudson.plugins.sauce_ondemand;
 
+import com.google.common.collect.Lists;
 import com.saucelabs.ci.JobInformation;
 import com.saucelabs.saucerest.SauceREST;
 import hudson.model.AbstractBuild;
 import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
-import hudson.tasks.junit.CaseResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -15,11 +15,14 @@ import org.kohsuke.stapler.StaplerResponse;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -44,19 +47,16 @@ public class SauceOnDemandBuildAction extends AbstractAction {
      */
     public static final Pattern SESSION_ID_PATTERN = Pattern.compile("SauceOnDemandSessionID=([0-9a-fA-F]+)(?:.job-name=(.*))?");
 
-    private transient final SauceOnDemandBuildWrapper.SauceOnDemandLogParser logParser;
-
     private AbstractBuild<?, ?> build;
-    private List<JobInformation> jobInformation;
+    private transient List<JobInformation> jobInformation;
     @Deprecated
     private String accessKey;
     @Deprecated
     private String username;
 
     @DataBoundConstructor
-    public SauceOnDemandBuildAction(AbstractBuild<?, ?> build, SauceOnDemandBuildWrapper.SauceOnDemandLogParser logParser) {
+    public SauceOnDemandBuildAction(AbstractBuild<?, ?> build) {
         this.build = build;
-        this.logParser = logParser;
     }
 
     public AbstractBuild<?, ?> getBuild() {
@@ -72,11 +72,10 @@ public class SauceOnDemandBuildAction extends AbstractAction {
     }
 
     public List<JobInformation> getJobs() {
-
         if (jobInformation == null) {
             try {
                 jobInformation = new ArrayList<JobInformation>();
-                jobInformation.addAll(retrieveJobIdsFromSauce());
+                jobInformation.addAll(retrieveJobIdsFromSauce(getSauceREST(), build).values());
             } catch (JSONException e) {
                 logger.log(Level.WARNING, "Unable to retrieve Job data from Sauce Labs", e);
             }
@@ -96,13 +95,12 @@ public class SauceOnDemandBuildAction extends AbstractAction {
      * @return List of processed job information
      * @throws JSONException Not json returned properly
      */
-    public List<JobInformation> retrieveJobIdsFromSauce() throws JSONException {
+    public static LinkedHashMap<String, JobInformation> retrieveJobIdsFromSauce(SauceREST sauceREST, AbstractBuild build) throws JSONException {
         SauceCredentials credentials = SauceCredentials.getCredentials(build);
 
         //invoke Sauce Rest API to find plan results with those values
-        List<JobInformation> jobInformation = new ArrayList<JobInformation>();
+        LinkedHashMap<String, JobInformation> jobInformation = new LinkedHashMap<String, JobInformation>();
 
-        JenkinsSauceREST sauceREST = getSauceREST();
         String buildNumber = SauceOnDemandBuildWrapper.sanitiseBuildNumber(SauceEnvironmentUtil.getBuildName(build));
         logger.fine("Performing Sauce REST retrieve results for " + buildNumber);
         String jsonResponse = sauceREST.getBuildFullJobs(buildNumber);
@@ -112,18 +110,16 @@ public class SauceOnDemandBuildAction extends AbstractAction {
             logger.log(Level.WARNING, "Unable to find job data for " + buildNumber);
 
         } else {
-            for (int i = 0; i < jobResults.length(); i++) {
+            //the list of results retrieved from the Sauce REST API is last-first, so reverse the list
+            for (int i = jobResults.length(); i > 0; i--) {
                 //check custom data to find job that was for build
                 JSONObject jobData = jobResults.getJSONObject(i);
                 String jobId = jobData.getString("id");
                 JobInformation information = new JenkinsJobInformation(jobId, credentials.getHMAC(jobId));
                 information.populateFromJson(jobData);
-                jobInformation.add(information);
+                jobInformation.put(information.getJobId(), information);
             }
-            //the list of results retrieved from the Sauce REST API is last-first, so reverse the list
-            Collections.reverse(jobInformation);
         }
-
         return jobInformation;
     }
 
@@ -136,66 +132,6 @@ public class SauceOnDemandBuildAction extends AbstractAction {
 
     public SauceTestResultsById getById(String id) {
         return new SauceTestResultsById(id, getCredentials());
-    }
-
-    protected JobInformation jobInformationForBuild(String jobId) {
-        for (JobInformation jobInfo : getJobs()) {
-            if (jobId.equals(jobInfo.getJobId())) {
-                return jobInfo;
-            }
-        }
-        return null;
-    }
-
-    public SauceOnDemandBuildWrapper.SauceOnDemandLogParser getLogParser() {
-        return logParser;
-    }
-
-    /**
-     * Processes the log output, and for lines which are in the valid log format, add a new {@link JobInformation}
-     * instance to the {@link #jobInformation} list.
-     *
-     * @param caseResult test results being processed, can be null
-     * @param output     lines of output to be processed, not null
-     */
-    public void processSessionIds(CaseResult caseResult, String... output) {
-        SauceCredentials credentials = SauceCredentials.getCredentials(build);
-
-        logger.log(Level.FINE, caseResult == null ? "Parsing Sauce Session ids in stdout" : "Parsing Sauce Session ids in test results");
-        SauceREST sauceREST = getSauceREST();
-
-        for (String text : output) {
-            if (text == null) continue;
-            Matcher m = SESSION_ID_PATTERN.matcher(text);
-            while (m.find()) {
-                String jobId = m.group(1);
-                String jobName = null;
-                if (m.groupCount() == 2) {
-                    jobName = m.group(2);
-                }
-                JobInformation jobInfo = jobInformationForBuild(jobId);
-                if (jobInfo != null) {
-                    //we already have the job information stored, move to the next match
-                    continue;
-                }
-                try {
-                    jobInfo = new JenkinsJobInformation(jobId, credentials.getHMAC(jobId));
-                    //retrieve data from session id to see if build number and/or job name has been stored
-                    String jsonResponse = sauceREST.getJobInfo(jobId);
-                    if (!jsonResponse.equals("")) {
-                        JSONObject job = new JSONObject(jsonResponse);
-                        jobInfo.populateFromJson(job);
-                    }
-                    if (!jobInfo.hasJobName() && jobName != null) {
-                        jobInfo.setName(jobName);
-                    }
-                    jobInformation.add(jobInfo);
-                } catch (JSONException e) {
-                    logger.log(Level.WARNING, "Unable to retrieve Job data from Sauce Labs", e);
-                }
-
-            }
-        }
     }
 
     /**
@@ -215,5 +151,7 @@ public class SauceOnDemandBuildAction extends AbstractAction {
         }
     }
 
-
+    public void setJobs(List<JobInformation> jobs) {
+        this.jobInformation = jobs;
+    }
 }

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -428,7 +428,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                 if (buildVariables.containsKey(SELENIUM_PLATFORM)) {
                     SauceEnvironmentUtil.outputEnvironmentVariable(env, SELENIUM_PLATFORM, (String) buildVariables.get(SELENIUM_PLATFORM), true, verboseLogging, listener.getLogger());
                 }
-                SauceEnvironmentUtil.outputEnvironmentVariable(env, JENKINS_BUILD_NUMBER, sanitiseBuildNumber(build.toString()), true, verboseLogging, listener.getLogger());
+                SauceEnvironmentUtil.outputEnvironmentVariable(env, JENKINS_BUILD_NUMBER, SauceOnDemandBuildWrapper.sanitiseBuildNumber(SauceEnvironmentUtil.getBuildName(build)), true, verboseLogging, listener.getLogger());
                 /* Legacy Env name */
                 SauceEnvironmentUtil.outputEnvironmentVariable(env, SAUCE_USER_NAME, username, true, verboseLogging, listener.getLogger());
                 /* New standard env name */

--- a/src/main/java/hudson/plugins/sauce_ondemand/TestIDDetails.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/TestIDDetails.java
@@ -1,0 +1,57 @@
+package hudson.plugins.sauce_ondemand;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by gavinmogan on 2016-04-20.
+ */
+public class TestIDDetails {
+    public static final Pattern SESSION_ID_PATTERN = Pattern.compile("SauceOnDemandSessionID=([0-9a-fA-F]+)(?:.job-name=(.*))?");
+    private final String jobId;
+    private final String jobName;
+
+    public TestIDDetails(String jobId, String jobName) {
+
+        this.jobId = jobId;
+        this.jobName = jobName;
+    }
+
+    public static TestIDDetails processString(@Nonnull String line) {
+        Matcher m = SESSION_ID_PATTERN.matcher(line);
+        if (!m.find()) { return null; }
+        TestIDDetails details = new TestIDDetails(
+            m.group(1),
+            m.groupCount() >= 2 ? m.group(2) : null
+        );
+        return details;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TestIDDetails that = (TestIDDetails) o;
+
+        if (jobId != null ? !jobId.equals(that.jobId) : that.jobId != null) return false;
+        return jobName != null ? jobName.equals(that.jobName) : that.jobName == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = jobId != null ? jobId.hashCode() : 0;
+        result = 31 * result + (jobName != null ? jobName.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceOnDemandReportPublisherTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceOnDemandReportPublisherTest.java
@@ -1,0 +1,51 @@
+package hudson.plugins.sauce_ondemand;
+
+import com.saucelabs.ci.JobInformation;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SauceOnDemandReportPublisherTest {
+
+    @Test
+    public void testProcessSessionIds_none() throws Exception {
+        SauceOnDemandBuildAction sauceOnDemandBuildAction;
+
+        LinkedList<TestIDDetails> details = SauceOnDemandReportPublisher.processSessionIds(null, new String[]{});
+        assertTrue(details.isEmpty());
+    }
+
+    @Test
+    public void testProcessSessionIds_one() throws Exception{
+        SauceOnDemandBuildAction sauceOnDemandBuildAction;
+        List<JobInformation> jobs;
+
+        LinkedList<TestIDDetails> details = SauceOnDemandReportPublisher.processSessionIds(null, new String[]{
+            "SauceOnDemandSessionID=abc123 job-name=gavin"
+        });
+        assertFalse(details.isEmpty());
+        assertEquals(1, details.size());
+        assertEquals("abc123", details.get(0).getJobId());
+    }
+
+    @Test
+    public void testProcessSessionIds_two() throws Exception {
+        SauceOnDemandBuildAction sauceOnDemandBuildAction;
+        List<JobInformation> jobs;
+
+        LinkedList<TestIDDetails> details = SauceOnDemandReportPublisher.processSessionIds(null, new String[]{
+            "SauceOnDemandSessionID=abc123 job-name=gavin\n[firefox 32 OS X 10.10 #1-5] SauceOnDemandSessionID=941b498c5ad544dba92fe73fabfa9eb6 job-name=Insert Job Name Here"
+        });
+        assertFalse(details.isEmpty());
+        assertEquals(2, details.size());
+        assertEquals("abc123", details.get(0).getJobId());
+        assertEquals("941b498c5ad544dba92fe73fabfa9eb6", details.get(1).getJobId());
+    }
+
+}


### PR DESCRIPTION
@moizjv 

Refactored a bunch of code, key items:
* Deleted the "log parser" as we don't use it for anything other than storing the log
* Post job now uses the input stream which is nicer for memory
* Grab up to 5000 (original was 100) of the jobs attached to a job, and then fill in any gaps
* Handle maven job naming by using the build name from the top level.

Probably a few other minor cleanups.