### PR TITLE
ECO-1067 - Make Jenkins Pipeline support "Run Sauce Labs Test Publisher"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,33 +8,15 @@ httpclient.log.zip
 
 httpclient.log
 
-atlassian-ide-plugin.xml
-
-lightweight.log
-
-sauce_connect.log
-
-sauce_connect.log.8
+lightweight.log*
 
 settings.xml
 
 jenkins.bmml
 
-lightweight.log.zip
-
-sauce_connect.log.1
-
-sauce_connect.log.2
-
-sauce_connect.log.3
-
-sauce_connect.log.4
-
-sauce_connect.log.5
-
-sauce_connect.log.6
-
-sauce_connect.log.7
+sauce_connect.log.*
 
 test.log
 .idea/
+
+src/main/java/hudson/plugins/sauce_ondemand/BuildUtils.java

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,9 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -151,6 +153,12 @@
                     <artifactId>xml-apis</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Dependencies on other Jenkins plugins -->

--- a/src/main/java/com/saucelabs/jenkins/pipeline/SauceStep.java
+++ b/src/main/java/com/saucelabs/jenkins/pipeline/SauceStep.java
@@ -9,6 +9,8 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TopLevelItem;
+import hudson.plugins.sauce_ondemand.SauceEnvironmentUtil;
+import hudson.plugins.sauce_ondemand.SauceOnDemandBuildAction;
 import hudson.plugins.sauce_ondemand.SauceOnDemandBuildWrapper;
 import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import hudson.util.ListBoxModel;
@@ -62,6 +64,13 @@ public class SauceStep extends AbstractStepImpl {
             HashMap<String,String> overrides = new HashMap<String,String>();
             overrides.put(SauceOnDemandBuildWrapper.SAUCE_USERNAME, credentials.getUsername());
             overrides.put(SauceOnDemandBuildWrapper.SAUCE_ACCESS_KEY, credentials.getPassword().getPlainText());
+            overrides.put(SauceOnDemandBuildWrapper.JENKINS_BUILD_NUMBER, SauceEnvironmentUtil.getSanitizedBuildNumber(run));
+
+            SauceOnDemandBuildAction buildAction = run.getAction(SauceOnDemandBuildAction.class);
+            if (buildAction == null) {
+                buildAction = new SauceOnDemandBuildAction(run, credentials.getId());
+                run.addAction(buildAction);
+            }
 
             body = getContext().newBodyInvoker()
                 .withContext(credentials)

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -2,12 +2,9 @@ package hudson.plugins.sauce_ondemand;
 
 import com.saucelabs.ci.Browser;
 import hudson.maven.MavenBuild;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildableItemWithBuildWrappers;
-import hudson.model.Descriptor;
-import hudson.tasks.BuildWrapper;
-import hudson.util.DescribableList;
+import hudson.model.Run;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -213,7 +210,7 @@ public final class SauceEnvironmentUtil {
      * @return String representing the Jenkins build
      */
     @Nonnull
-    public static String getBuildName(AbstractBuild<?, ?> build) {
+    public static String getBuildName(Run<?, ?> build) {
         if (build == null) {
             return "";
         }
@@ -237,4 +234,9 @@ public final class SauceEnvironmentUtil {
         String sanitizedName = projectName.replaceAll(PATTERN_DISALLOWED_TUNNEL_ID_CHARS, "_");
         return sanitizedName + "-" + System.currentTimeMillis();
     }
+
+    public static String getSanitizedBuildNumber(Run run) {
+        return SauceEnvironmentUtil.getBuildName(run).replaceAll("[^A-Za-z0-9]", "_");
+    }
+
 }

--- a/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
@@ -22,6 +22,7 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Run;
 import hudson.plugins.sauce_ondemand.JenkinsSauceREST;
 import hudson.plugins.sauce_ondemand.SauceOnDemandBuildWrapper;
 import hudson.security.ACL;

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction/jobMain.jelly
@@ -1,0 +1,50 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <j:if test="${from.isSauceEnabled()}">
+        <h2>Sauce Labs results</h2>
+
+        <div>
+            <j:choose>
+                <j:when test="${from.hasSauceOnDemandResults()}">
+                    <div>
+                        <table>
+                            <tr>
+                                <th align="left">Job Name</th>
+                                <th align="left">OS/Browser</th>
+                                <th align="left">Pass/Fail</th>
+                                <th align="left">Job Links</th>
+                            </tr>
+                            <j:forEach var="job" items="${from.getJobsWithAuth()}" indexVar="indexA">
+                                <tr>
+                                    <td>
+                                        <a href="${from.urlName}/jobReport?jobId=${job.getJobId()}">${job.getName()}</a>
+                                    </td>
+                                    <td>${job.getOs()} ${job.getBrowser()} ${job.getVersion()}</td>
+                                    <td>${job.getStatus()}</td>
+                                    <td>
+                                        <a href="${job.getVideoUrl()}">Video</a>
+                                        -
+                                        <a href="${job.getLogUrl()}">Logs</a>
+                                    </td>
+                                </tr>
+                            </j:forEach>
+                        </table>
+                    </div>
+
+                </j:when>
+                <j:otherwise>
+                    <div>
+                        No Sauce results found
+                    </div>
+                </j:otherwise>
+            </j:choose>
+
+        </div>
+        <hr />
+        <j:if test="${h.hasPermission(from.project, from.project.CONFIGURE)}">
+            <div >
+                <a id="generateSauceReport" href="${from.urlName}/generateSupportZip">Generate Sauce Support Zip</a>
+            </div>
+        </j:if>
+    </j:if>
+</j:jelly>

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
@@ -378,7 +378,7 @@ public class SauceBuildWrapperTest {
         freeStyleProject.getBuildersList().add(builder);
         SauceOnDemandReportPublisher publisher = new SauceOnDemandReportPublisher() {
             @Override
-            protected SauceREST getSauceREST(AbstractBuild build) {
+            protected SauceREST getSauceREST(Run build) {
                 return spySauceRest;
             }
         };

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildActionTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildActionTest.java
@@ -3,27 +3,23 @@ package hudson.plugins.sauce_ondemand;
 import com.gargoylesoftware.htmlunit.html.DomNodeList;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.saucelabs.ci.JobInformation;
 import hudson.model.Build;
-import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import hudson.plugins.sauce_ondemand.mocks.MockSauceREST;
 import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.io.IOException;
 import java.net.URL;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -53,7 +49,7 @@ public class SauceOnDemandBuildActionTest {
         bw.setEnableSauceConnect(false);
         freeStyleProject.getBuildWrappersList().add(bw);
         Build build = freeStyleProject.scheduleBuild2(0).get();
-        SauceOnDemandBuildAction buildAction = new SauceOnDemandBuildAction(build) {
+        SauceOnDemandBuildAction buildAction = new SauceOnDemandBuildAction(build, bw.getCredentialId()) {
             @Override
             protected JenkinsSauceREST getSauceREST() {
                 return mockSauceREST;


### PR DESCRIPTION
* Mostly changes to switch from AbstractBuild to Run where appropriate
* BuildAction will now store credentials id so it doesn't need to look
  it up in the build wrapper so it can display results
* Project action will now be added on the fly by the build action
* Broke support zip usefulness a bit, will have to rething that.