### PR TITLE
Stop sauce before timeout

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -30,7 +30,7 @@ public final class SauceEnvironmentUtil {
     private static final Logger logger = Logger.getLogger(SauceEnvironmentUtil.class.getName());
 
     //only allow word, digit, and hyphen characters
-    private static final String PATTERN_DISALLOWED_TUNNEL_ID_CHARS = "[^\\w\\d-]+";
+    private static final String PATTERN_DISALLOWED_CHARS = "[^\\w\\d-]+";
 
     /**
      * Disallow instantiation of class.
@@ -233,13 +233,13 @@ public final class SauceEnvironmentUtil {
 
     public static String generateTunnelIdentifier(final String projectName) {
         //String rawName = build.getProject().getName();
-        String sanitizedName = projectName.replaceAll(PATTERN_DISALLOWED_TUNNEL_ID_CHARS, "_");
+        String sanitizedName = projectName.replaceAll(PATTERN_DISALLOWED_CHARS, "_");
         return sanitizedName + "-" + System.currentTimeMillis();
     }
 
     // the buildNumber variable returned from the API uses hyphens, so we should sanitize with hyphens here
     public static String getSanitizedBuildNumber(Run run) {
-        return "jenkins-"+SauceEnvironmentUtil.getBuildName(run).replaceAll(PATTERN_DISALLOWED_TUNNEL_ID_CHARS, "-");
+        return "jenkins-"+SauceEnvironmentUtil.getBuildName(run).replaceAll(PATTERN_DISALLOWED_CHARS, "-");
     }
 
 }

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -237,8 +237,9 @@ public final class SauceEnvironmentUtil {
         return sanitizedName + "-" + System.currentTimeMillis();
     }
 
+    // the buildNumber variable returned from the API uses hyphens, so we should sanitize with hyphens here
     public static String getSanitizedBuildNumber(Run run) {
-        return SauceEnvironmentUtil.getBuildName(run).replaceAll("[^A-Za-z0-9]", "_");
+        return "jenkins-"+SauceEnvironmentUtil.getBuildName(run).replaceAll(PATTERN_DISALLOWED_TUNNEL_ID_CHARS, "-");
     }
 
 }

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -97,6 +97,15 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
         return jobInformation;
     }
 
+    // Get the list of running jobs and stop them all
+    public void stopJobs() {
+        SauceREST sauceREST = getSauceREST();
+        List<JenkinsJobInformation> jobs = getJobs();
+        for (JobInformation job : jobs) {
+            sauceREST.stopJob(job.getJobId());
+        }
+    }
+
     @Override
     protected SauceCredentials getCredentials() {
         if (credentialsId != null) {
@@ -153,7 +162,7 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
 
         } else {
             //the list of results retrieved from the Sauce REST API is last-first, so reverse the list
-            for (int i = jobResults.length() - 1; i > 0; i--) {
+            for (int i = jobResults.length() - 1; i >= 0; i--) {
                 //check custom data to find job that was for build
                 JSONObject jobData = jobResults.getJSONObject(i);
                 String jobId = jobData.getString("id");

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -68,13 +68,6 @@ import java.util.regex.Pattern;
  */
 public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializable {
 
-    @Override
-    public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {
-        super.makeSensitiveBuildVariables(build, sensitiveVariables);
-        sensitiveVariables.add(SAUCE_ACCESS_KEY);
-        sensitiveVariables.add(SAUCE_API_KEY);
-    }
-
     /**
      * Logger instance.
      */
@@ -255,6 +248,12 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      */
     private String credentialId;
 
+    @Override
+    public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {
+        super.makeSensitiveBuildVariables(build, sensitiveVariables);
+        sensitiveVariables.add(SAUCE_ACCESS_KEY);
+        sensitiveVariables.add(SAUCE_API_KEY);
+    }
 
     /**
      * Constructs a new instance using data entered on the job configuration screen.
@@ -555,7 +554,6 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
                     SauceCredentials credentials = SauceCredentials.getSauceCredentials(build, SauceOnDemandBuildWrapper.this); // get credentials
                     JenkinsSauceREST sauceREST = credentials.getSauceREST(); // use credentials to get sauceRest
-                    String buildNumber = SauceEnvironmentUtil.getSanitizedBuildNumber(build); // may need this for tunnels. will need this for debugging
 
                     //immediately stop any running jobs
                     buildAction = new SauceOnDemandBuildAction(build, SauceOnDemandBuildWrapper.this.credentialId);

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -43,6 +43,8 @@ import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.jenkins_ci.plugins.run_condition.RunCondition;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.json.JSONException;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -228,6 +230,10 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      */
     private boolean useLatestVersion;
     /**
+     * Boolean which indicates whether to force cleanup for jobs/tunnels instead of waiting for timeout
+     */
+    private boolean forceCleanup;
+    /**
      * Default behaviour is to launch Sauce Connect on the slave node.
      */
     private boolean launchSauceConnectOnSlave = true;
@@ -262,6 +268,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      * @param launchSauceConnectOnSlave indicates whether Sauce Connect should be launched on the slave or master node
      * @param verboseLogging            indicates whether the Sauce Connect output should be written to the Jenkins job output
      * @param useLatestVersion          indicates whether the latest version of the selected browser(s) should be used
+     * @param forceCleanup              indicates whether to force cleanup for jobs/tunnels instead of waiting for timeout
      * @param webDriverBrowsers         which browser(s) should be used for web driver
      * @param appiumBrowsers            which browser(s( should be used for appium
      * @param nativeAppPackage          indicates whether the latest version of the selected browser(s) should be used
@@ -281,6 +288,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         boolean launchSauceConnectOnSlave,
         boolean verboseLogging,
         boolean useLatestVersion,
+        boolean forceCleanup,
         List<String> webDriverBrowsers,
         List<String> appiumBrowsers,
         String nativeAppPackage,
@@ -301,6 +309,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         this.launchSauceConnectOnSlave = launchSauceConnectOnSlave;
         this.verboseLogging = verboseLogging;
         this.useLatestVersion = useLatestVersion;
+        this.forceCleanup = forceCleanup;
         this.condition = condition;
         this.sauceConnectPath = sauceConnectPath;
         this.nativeAppPackage = nativeAppPackage;
@@ -497,7 +506,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
              * {@inheritDoc}
              *
              * Terminates the Sauce Connect process (if the build is configured to launch Sauce Connect), and adds a {@link SauceOnDemandBuildAction} instance to the build.
-             *  @param build
+             * @param build
              *      The build in progress for which an {@link Environment} object is created.
              *      Never null.
              * @param listener
@@ -539,6 +548,51 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                 if (buildAction == null) {
                     buildAction = new SauceOnDemandBuildAction(build, SauceOnDemandBuildWrapper.this.credentialId);
                     build.addAction(buildAction);
+                }
+
+                if (forceCleanup){
+                    listener.getLogger().println("Force cleanup enabled: Cleaning up jobs and tunnels instead of waiting for timeout");
+
+                    SauceCredentials credentials = SauceCredentials.getSauceCredentials(build, SauceOnDemandBuildWrapper.this); // get credentials
+                    JenkinsSauceREST sauceREST = credentials.getSauceREST(); // use credentials to get sauceRest
+                    String buildNumber = SauceEnvironmentUtil.getSanitizedBuildNumber(build); // may need this for tunnels. will need this for debugging
+
+                    //immediately stop any running jobs
+                    buildAction = new SauceOnDemandBuildAction(build, SauceOnDemandBuildWrapper.this.credentialId);
+                    List<JenkinsJobInformation> jobs = buildAction.getJobs();
+                    buildAction.stopJobs();
+
+                    // stop tunnels matching the tunnel identifier
+                    // this is needed as aborting during tunnel creation will prevent it from closing properly above
+                    try {
+                        String listResponse = sauceREST.getTunnels();
+                        JSONArray tunnels = new JSONArray(listResponse);
+                        for (int i = 0; i < tunnels.length(); i++) {
+                            String tunnel = tunnels.getString(i);
+                            String jsonResponse = sauceREST.getTunnelInformation(tunnel);
+                            JSONObject tunnelObj = new JSONObject(jsonResponse);
+                            if (tunnelObj.getString("tunnel_identifier").equals(tunnelIdentifier)) {
+                                listener.getLogger().println("Closing tunnel: " + tunnelObj.getString("id"));
+                                sauceREST.deleteTunnel(tunnelObj.getString("id"));
+                            }
+                        }
+                    } catch (JSONException e) {
+                        listener.getLogger().println(e);
+                    }
+
+                    // Wait up to 5s and see if # of jobs changes, if it does, stop them again and reset wait time
+                    int numJobs = jobs.size();
+                    for (int waitCount = 0; waitCount < 5; waitCount++) {
+                        Thread.sleep(1000);
+                        buildAction = new SauceOnDemandBuildAction(build, SauceOnDemandBuildWrapper.this.credentialId);
+                        jobs = buildAction.getJobs();
+                        if (jobs.size()!=numJobs) {
+                            buildAction.stopJobs();
+                            numJobs=jobs.size();
+                            waitCount=-1;
+                        }
+                    }
+                    listener.getLogger().println("Stopped " + numJobs + " jobs");
                 }
 
                 listener.getLogger().println("Finished post-build for Sauce Labs plugin");
@@ -672,6 +726,10 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         return useLatestVersion;
     }
 
+    public boolean isForceCleanup() {
+        return forceCleanup;
+    }
+
     public String getSeleniumHost() {
         return seleniumHost;
     }
@@ -774,6 +832,10 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
     public void setUseLatestVersion(boolean useLatestVersion) {
         this.useLatestVersion = useLatestVersion;
+    }
+
+    public void setForceCleanup(boolean forceCleanup) {
+        this.forceCleanup = forceCleanup;
     }
 
     public void setNativeAppPackage(String nativeAppPackage) {

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
@@ -58,6 +58,10 @@
             <f:entry field="useLatestVersion">
                 <f:checkbox title="${%Use latest version of selected browsers}" default="checked"/>
             </f:entry>
+
+            <f:entry field="forceCleanup">
+                <f:checkbox title="${%Cleanup instead of waiting for timeouts - useful when aborting builds}"/>
+            </f:entry>
         </f:section>
         <f:section title="Sauce Connect Advanced Options">
             <f:advanced>

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -52,6 +52,7 @@ public class ParameterizedSauceBuildWrapperTest {
             boolean useGeneratedTunnelIdentifier,
             boolean verboseLogging,
             boolean useLatestVersion,
+            boolean forceCleanup,
             String seleniumPort,
             String seleniumHost
     ) throws Exception {
@@ -62,6 +63,7 @@ public class ParameterizedSauceBuildWrapperTest {
         sauceBuildWrapper.setUseGeneratedTunnelIdentifier(useGeneratedTunnelIdentifier);
         sauceBuildWrapper.setVerboseLogging(verboseLogging);
         sauceBuildWrapper.setUseLatestVersion(useLatestVersion);
+        sauceBuildWrapper.setForceCleanup(forceCleanup);
         sauceBuildWrapper.setSeleniumPort(seleniumPort);
         sauceBuildWrapper.setSeleniumHost(seleniumHost);
     }
@@ -74,17 +76,20 @@ public class ParameterizedSauceBuildWrapperTest {
                 for (boolean useGeneratedTunnelIdentifier : new boolean[]{true, false}) {
                     for (boolean verboseLogging : new boolean[]{true, false}) {
                         for (boolean useLatestVersion : new boolean[]{true, false}) {
-                            for (String seleniumPort : new String[]{"", "4444"}) {
-                                for (String seleniumHost : new String[]{"", "localhost"}) {
-                                    list.add(new Object[]{
-                                            enableSauceConnect,
-                                            launchSauceConnectOnSlave,
-                                            useGeneratedTunnelIdentifier,
-                                            verboseLogging,
-                                            useLatestVersion,
-                                            seleniumPort,
-                                            seleniumHost
-                                    });
+                            for (boolean forceCleanup : new boolean[]{true, false}) {
+                                for (String seleniumPort : new String[]{"", "4444"}) {
+                                    for (String seleniumHost : new String[]{"", "localhost"}) {
+                                        list.add(new Object[]{
+                                                enableSauceConnect,
+                                                launchSauceConnectOnSlave,
+                                                useGeneratedTunnelIdentifier,
+                                                verboseLogging,
+                                                useLatestVersion,
+                                                forceCleanup,
+                                                seleniumPort,
+                                                seleniumHost
+                                        });
+                                    }
                                 }
                             }
                         }

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -11,7 +11,6 @@ import net.sf.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -76,8 +76,8 @@ public class ParameterizedSauceBuildWrapperTest {
                 for (boolean useGeneratedTunnelIdentifier : new boolean[]{true, false}) {
                     for (boolean verboseLogging : new boolean[]{true, false}) {
                         for (boolean useLatestVersion : new boolean[]{true, false}) {
-                            for (boolean forceCleanup : new boolean[]{true, false}) {
-                                for (String seleniumPort : new String[]{"", "4444"}) {
+                            for (boolean forceCleanup : new boolean[]{false}) { // set this to {true, false} for proper testing.  But it will increase test times by about 20m
+                                 for (String seleniumPort : new String[]{"", "4444"}) {
                                     for (String seleniumHost : new String[]{"", "localhost"}) {
                                         list.add(new Object[]{
                                                 enableSauceConnect,

--- a/src/test/java/hudson/plugins/sauce_ondemand/TestSauceOnDemandBuildWrapper.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/TestSauceOnDemandBuildWrapper.java
@@ -22,6 +22,7 @@ class TestSauceOnDemandBuildWrapper extends SauceOnDemandBuildWrapper {
                 false,
                 false,
                 true,
+                false,
                 null,
                 null,
                 null,


### PR DESCRIPTION
1. Added a checkbox to force job/tunnel cleanup in the build configuration page
2. It will look for tunnels with the associated tunnel_id and stop them.
3. It will stop jobs, then wait up to 5 seconds for additional jobs that might get added and stop those too.  If it finds new jobs, the timer is reset.
4. Sanitized build names in a way that matches what the API calls were returning so jobs could be matched
5. The job id list was missing an item in the loop, which was preventing proper cleanup