### PR TITLE
Keep existing constructor for legacy scripts / config files

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
@@ -65,6 +65,11 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
 
     protected ShortLivedConfig shortLivedConfig;
 
+    public SauceCredentials(@CheckForNull CredentialsScope scope, @CheckForNull String id,
+                            @NonNull String username, @NonNull String apiKey, @CheckForNull String description) {
+        this(scope, id, username, apiKey, null, description);
+    }
+    
     @DataBoundConstructor
     public SauceCredentials(@CheckForNull CredentialsScope scope, @CheckForNull String id,
                             @NonNull String username, @NonNull String apiKey, @NonNull String restEndpoint, @CheckForNull String description) {


### PR DESCRIPTION
When changing the constructor, it means anyone using it by programmatic ways will (such as groovy startup scripts) suddenly have their scripts fail. Its good practice, at least in the short time, to leave old constructors in place. Maybe with a @deprecated annotation.