### PR TITLE
Fix premature api fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Jenkins 1.186 - 2019-07-11
+
+* Make additional attempts to fetch build information from the Saucelabs API if responses are invalid
+
 # Jenkins 1.185 - 2019-07-09
 
 * Add us-east (sauce headless) data center support


### PR DESCRIPTION
What I was noticing was that our saucelabs builds and also the API results would often take longer than the job to show up.  Adam said this was because of the Curator which is old and buggy, and shouldn't normally take that long (a few seconds).  But with this fix and what I output to the logs, it seems like it often takes up to a minute before our API will return completely valid results (it's either completely missing, or is missing values for certain fields like start_time)